### PR TITLE
Bugfix: Simultaneous insert and delete

### DIFF
--- a/lib/editor.js
+++ b/lib/editor.js
@@ -85,6 +85,7 @@ class Editor {
         case 'undo':
           this.processUndoRedo(changeObj);
           break;
+        case 'compose':
         case '+input':
 //          this.processInsert(changeObj);    // uncomment this line for palindromes!
         case 'paste':
@@ -101,6 +102,7 @@ class Editor {
   }
 
   processInsert(changeObj) {
+    this.processDelete(changeObj);
     const chars = this.extractChars(changeObj.text);
     const startPos = changeObj.from;
 
@@ -108,7 +110,12 @@ class Editor {
     this.controller.localInsert(chars, startPos);
   }
 
+  isEmpty(textArr) {
+    return textArr.length === 1 && textArr[0].length === 0;
+  }
+
   processDelete(changeObj) {
+    if (this.isEmpty(changeObj.removed)) return;
     const startPos = changeObj.from;
     const endPos = changeObj.to;
     const chars = this.extractChars(changeObj.removed);

--- a/lib/editor.js
+++ b/lib/editor.js
@@ -85,7 +85,7 @@ class Editor {
         case 'undo':
           this.processUndoRedo(changeObj);
           break;
-        case 'compose':
+        case '*compose':
         case '+input':
 //          this.processInsert(changeObj);    // uncomment this line for palindromes!
         case 'paste':


### PR DESCRIPTION
Fixes the inconsistency bug that occurs because of simultaneous insert/delete events via highlighting text and inserting a character. Simple fix. Just delete the characters in the `removed` array first and then process the inserts.

Also whitelisted `*compose` events so that Chinese and other foreign characters can be inserted.

closes #8 and #6 