### PR TITLE
fix new line deletion bug in Chrome and Firefox

### DIFF
--- a/lib/crdt.js
+++ b/lib/crdt.js
@@ -47,42 +47,58 @@ class CRDT {
   }
 
   handleLocalDelete(startPos, endPos) {
-    let chars, line, ch, i, charNum;
+    let chars;
     let newlineRemoved = false;
 
     // for multi-line deletes
     if (startPos.line !== endPos.line) {
       // delete chars on first line from startPos.ch to end of line
       newlineRemoved = true;
-      chars = this.struct[startPos.line].splice(startPos.ch);
-
-      for (line = startPos.line + 1; line < endPos.line; line++) {
-        chars = chars.concat(this.struct[line].splice(0));
-      }
-
-      // todo for loop inside crdt
-      if (this.struct[endPos.line]) {
-        chars = chars.concat(this.struct[endPos.line].splice(0, endPos.ch));
-      }
+      chars = this.deleteMultipleLines(startPos, endPos)
 
       // single-line deletes
     } else {
-      charNum = endPos.ch - startPos.ch;
-      chars = this.struct[startPos.line].splice(startPos.ch, charNum);
+      chars = this.deleteSingleLine(startPos, endPos)
 
       if (chars.find(char => char.value === '\n')) newlineRemoved = true;
     }
 
-    chars.forEach(char => {
-      this.vector.increment();
-      this.controller.broadcastDeletion(char, this.vector.getLocalVersion());
-    });
-
+    this.broadcast(chars);
     this.removeEmptyLines();
 
     if (newlineRemoved && this.struct[startPos.line + 1]) {
       this.mergeLines(startPos.line);
     }
+  }
+
+  broadcast(chars) {
+    chars.forEach(char => {
+      this.vector.increment();
+      this.controller.broadcastDeletion(char, this.vector.getLocalVersion());
+    });
+  }
+
+  deleteMultipleLines(startPos, endPos) {
+    let chars = this.struct[startPos.line].splice(startPos.ch);
+    let line;
+
+    for (line = startPos.line + 1; line < endPos.line; line++) {
+      chars = chars.concat(this.struct[line].splice(0));
+    }
+
+    // todo for loop inside crdt
+    if (this.struct[endPos.line]) {
+      chars = chars.concat(this.struct[endPos.line].splice(0, endPos.ch));
+    }
+
+    return chars;
+  }
+
+  deleteSingleLine(startPos, endPos) {
+    let charNum = endPos.ch - startPos.ch;
+    let chars = this.struct[startPos.line].splice(startPos.ch, charNum);
+
+    return chars;
   }
 
   // when deleting newline, concat line with next line

--- a/lib/crdt.js
+++ b/lib/crdt.js
@@ -61,7 +61,9 @@ class CRDT {
       }
 
       // todo for loop inside crdt
-      chars = chars.concat(this.struct[endPos.line].splice(0, endPos.ch));
+      if (this.struct[endPos.line]) {
+        chars = chars.concat(this.struct[endPos.line].splice(0, endPos.ch));
+      }
 
       // single-line deletes
     } else {


### PR DESCRIPTION
I was sometimes getting an console error whenever I would try to delete a new-line character. I narrowed it down to a line of code in the `CRDT` class in the `handleLocalDelete` method. The method would try to remove characters from a line even if there were no characters on that line. I added a guard clause to handle the error.

I also realized the logic on the `handleLocalDelete` method was pretty complicated so I refactored it into several smaller methods so that it's easier to read.

closes #5 