### PR TITLE
Fixed line wrapping issue

### DIFF
--- a/lib/remoteCursor.js
+++ b/lib/remoteCursor.js
@@ -41,11 +41,16 @@ export default class RemoteCursor {
     this.cursor.style.left = (coords.left >= 0 ? coords.left : 0) + 'px';
     this.mde.codemirror.getDoc().setBookmark(position, { widget: this.cursor });
     this.lastPosition = position;
+    
+    // Add a zero width-space so line wrapping works (on firefox?)
+    this.cursor.parentElement.appendChild(document.createTextNode("\u200b"));
   }
 
   detach() {
-    if (this.cursor.parentElement) {
-        this.cursor.parentElement.remove();
-    }
+    // Used when updating cursor position.
+    // If cursor exists on the DOM, remove it.  
+    // DO NOT remove cursor's parent. It contains the zero width-space.
+    if (this.cursor.parentElement)
+      this.cursor.remove();
   }
 }


### PR DESCRIPTION
Applying remote operations that require to insert or delete a line is not working properly on some browsers.
Remote cursors are also not functioning properly as a result.

Adding a zero width-space text node after the cursor node fixes these issues.

